### PR TITLE
Fixed #26 TypeError when creating new product, or saving existing product in Craft CP

### DIFF
--- a/src/services/CurrencyPricesService.php
+++ b/src/services/CurrencyPricesService.php
@@ -36,8 +36,12 @@ class CurrencyPricesService extends Component
     // Public Methods
     // =========================================================================
 
-    public function getPricesByPurchasableId(int $id): mixed
+    public function getPricesByPurchasableId(?int $id): mixed
     {
+        if ($id === null) {
+            return null;
+        }
+
         $result = (new Query())
             ->select(['*'])
             ->from(['{{%commerce_currencyprices}}'])


### PR DESCRIPTION
Changed the parameter type from int to ?int to allow null values. 
Added a null check at the beginning of the method that returns null if the ID is null.